### PR TITLE
Escape equals sign in query parameter values

### DIFF
--- a/docs/details.md
+++ b/docs/details.md
@@ -41,8 +41,7 @@ The specification linked to above says that all tabs and newlines should be remo
 Then there are different escaping rules for different parts of [AppUrl][appurl-type]:
 
 - path: `/`, `?` and `#` are escaped as well. Slash because it starts a new segment. Question mark and hash since it starts the query and fragment, respectively.
-- query key: `=`, `&`, `#` and `+` are escaped as well. Equals since it starts the value, ampersand since it starts a new query parameter, hash since it starts the fragment and plus since it’s treated as a space in the query part. Also, spaces are escaped as `+` – see [Plus and space].
-- query value: `&`, `#` and `+` are escaped as well, for the same reasons as above. Note that `?k=1=2` is valid; the value is `1=2`. Also, spaces are escaped as `+` – see [Plus and space].
+- query key and value: `=`, `&`, `#` and `+` are escaped as well. Equals since it starts the value, ampersand since it starts a new query parameter, hash since it starts the fragment and plus since it’s treated as a space in the query part. Also, spaces are escaped as `+` – see [Plus and space]. Note that `?k=1=2` is technically valid; the value is `1=2`. elm-app-url escapes the second equals sign anyway, to be compatible with naive parsing code that splits on `=` and assumes it returns a list with only one or two items ([example][suave-naive-parsing]).
 - fragment: No more escaping. The fragment goes on til the end of the URL.
 
 The idea is that URLs are very loosely defined in what characters are allowed and which ones aren’t. Browsers seem to support basically any characters (possibly looser than some specification says, but hey – we run Elm code in browsers!). Escaping just the bare minimum means we don’t escape letters from non-English languages (like `ä` or `π`) into ugly percent sequences.
@@ -84,6 +83,7 @@ Finally, what about relative URLs? I recommend not using them at all. This packa
 [django]: https://docs.djangoproject.com/en/4.1/ref/request-response/#django.http.QueryDict.__getitem__
 [elm/url]: https://package.elm-lang.org/packages/elm/url/latest
 [plus and space]: #plus-and-space
+[suave-naive-parsing]: https://github.com/SuaveIO/suave/blob/8efe4b32ea0dc52f36c10c8d8fec8191c6ae901c/src/Suave/Utils/Parsing.fs#L18-L27
 [url]: https://package.elm-lang.org/packages/elm/url/latest/Url#Url
 [urlsearchparams.get()]: https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/get
 [urlsearchparams]: https://url.spec.whatwg.org/#example-constructing-urlsearchparams

--- a/src/AppUrl.elm
+++ b/src/AppUrl.elm
@@ -195,10 +195,10 @@ queryParameterToString ( key, values ) =
                 -- print nothing at all which would lose this “parameter” next
                 -- time we parse.
                 if not (String.isEmpty key) && String.isEmpty value then
-                    percentEncode Escape.QueryKey key
+                    percentEncode Escape.Query key
 
                 else
-                    percentEncode Escape.QueryKey key ++ "=" ++ percentEncode Escape.QueryValue value
+                    percentEncode Escape.Query key ++ "=" ++ percentEncode Escape.Query value
             )
 
 

--- a/src/Escape.elm
+++ b/src/Escape.elm
@@ -3,8 +3,7 @@ module Escape exposing (Part(..), forAll)
 
 type Part
     = Path
-    | QueryKey
-    | QueryValue
+    | Query
     | Fragment
 
 
@@ -14,10 +13,7 @@ shouldHandlePlusAndSpace part =
         Path ->
             False
 
-        QueryKey ->
-            True
-
-        QueryValue ->
+        Query ->
             True
 
         Fragment ->
@@ -30,11 +26,8 @@ escapePart part =
         Path ->
             forPath
 
-        QueryKey ->
-            forQueryKey
-
-        QueryValue ->
-            forQueryValue
+        Query ->
+            forQuery
 
         Fragment ->
             String.fromChar
@@ -233,25 +226,12 @@ forPath char =
             String.fromChar char
 
 
-forQueryKey : Char -> String
-forQueryKey char =
+forQuery : Char -> String
+forQuery char =
     case char of
         '=' ->
             "%3D"
 
-        '&' ->
-            "%26"
-
-        '#' ->
-            "%23"
-
-        _ ->
-            String.fromChar char
-
-
-forQueryValue : Char -> String
-forQueryValue char =
-    case char of
         '&' ->
             "%26"
 

--- a/tests/AppUrlTest.elm
+++ b/tests/AppUrlTest.elm
@@ -468,18 +468,18 @@ escaping =
             \() ->
                 AppUrl.toString
                     { path = []
-                    , queryParameters = Dict.singleton "a" [ "&", "#", "+" ]
+                    , queryParameters = Dict.singleton "a" [ "&", "#", "+", "=" ]
                     , fragment = Nothing
                     }
-                    |> Expect.equal "/?a=%26&a=%23&a=%2B"
+                    |> Expect.equal "/?a=%26&a=%23&a=%2B&a=%3D"
         , test "query value non-escapes" <|
             \() ->
                 AppUrl.toString
                     { path = []
-                    , queryParameters = Dict.singleton "a" [ "/", "?", "=" ]
+                    , queryParameters = Dict.singleton "a" [ "/", "?" ]
                     , fragment = Nothing
                     }
-                    |> Expect.equal "/?a=/&a=?&a=="
+                    |> Expect.equal "/?a=/&a=?"
         , test "fragment non-escapes" <|
             \() ->
                 AppUrl.toString


### PR DESCRIPTION
To be more compatible with bad parsing (naive split on `=`) I suspect is common.

Here’s one bug report about this in a server framework: https://github.com/SuaveIO/suave/issues/774